### PR TITLE
Fixing the realm users tab and functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 target/
 dependency-reduced-pom.xml
 pom.xml.versionsBackup
+
+.vscode/

--- a/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/realm/CassandraRealmAdapter.java
+++ b/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/realm/CassandraRealmAdapter.java
@@ -45,7 +45,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 
 @EqualsAndHashCode(callSuper = true)
 @JBossLog
-public class CassandraRealmAdapter extends TransactionalModelAdapter<Realm> implements RealmModel {
+public class CassandraRealmAdapter extends TransactionalModelAdapter<Realm> implements StorageProviderRealmModel {
     private static final String COMPONENT_PROVIDER_EXISTS_DISABLED =
             "component.provider.exists.disabled"; // Copied from MapRealmAdapter
     public static final String DEFAULT_GROUP_IDS = AttributeTypes.INTERNAL_ATTRIBUTE_PREFIX + "defaultGroupIds";

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+ datastax-java-driver {
+     profiles.write {}
+     profiles.read {}
+  }
+

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,4 +1,0 @@
-datastax-java-driver {
-    profiles.write {}
-    profiles.read {}
-}


### PR DESCRIPTION
 RealmModel is modifed to StorageProviderRealmModel such that corresponding Storage Provider Realm Model can be utilized. 
## Hey, I just made a Pull Request!

 Realm Model does not yet know the StorageProvider so the users related functionality fails as its stored in the database. Hence StorageProviderRealmModel understands the storage is cassandra as database in this case. Hence modified the implemented class. 
 Also for vscode users added in gitignore.

reference.conf is removed and application.conf is restored as earlier versions. In tests also we still use application.conf

#### :heavy_check_mark: Checklist

<!-- Hint: insert a [x] to check a checkbox -->
<!-- Please include the following in your Pull Request when applicable: -->

- [ ] Added or updated documentation
- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] The commits follow our [conventional commit and release guidelines](https://github.com/ba-itsys/.github/blob/main/docs/release-process.md)
- [x] The code is properly formated (eg. `mvn spotless:apply`)
- [] You agree to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) and thereby all your commits have a `Signed-off-by` line in the message


<!-- Questions? Have a look at
     https://github.com/ba-itsys/.github/blob/main/CONTRIBUTING.md

     Thanks for contributing! -->
